### PR TITLE
Add configurable sessionKey for CakeDC/Users compatibility

### DIFF
--- a/config/Migrations/20201109223940_MigrationFeedbackInit.php
+++ b/config/Migrations/20201109223940_MigrationFeedbackInit.php
@@ -56,11 +56,11 @@ class MigrationFeedbackInit extends AbstractMigration {
 				'limit' => MysqlAdapter::TEXT_MEDIUM, // Only needed for MySQL to store more than 65k
 				'null' => true,
 			])
-		   ->addColumn('priority', 'string', [
-				'default' => null,
-				'limit' => 20,
-				'null' => true,
-			])
+		->addColumn('priority', 'string', [
+			'default' => null,
+			'limit' => 20,
+			'null' => true,
+		])
 			->addColumn('status', 'integer', [
 				'default' => 0,
 				'limit' => 2,

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -5,8 +5,7 @@ use Feedback\Store\FilesystemStore;
 return [
 	'Feedback' => [
 
-		'stores' => [
-		], // FQCN. Only the first method will be checked and reported back to user
+		'stores' => [], // FQCN. Only the first method will be checked and reported back to user
 
 		'returnlink' => true, // Return a link (if any) to the created ticket or report.
 		'skipCss' => false, // For manually including stylesheet

--- a/src/Controller/FeedbackController.php
+++ b/src/Controller/FeedbackController.php
@@ -56,7 +56,7 @@ class FeedbackController extends AppController {
 	 * @return \Cake\Http\Response|null|void
 	 */
 	public function save() {
-	    $this->request->allowMethod(['put', 'post', 'ajax']);
+		$this->request->allowMethod(['put', 'post', 'ajax']);
 
 		$map = (array)Configure::read('Feedback.authMap') + [
 			'username' => 'username',
@@ -97,9 +97,9 @@ class FeedbackController extends AppController {
 		$data['sid'] = $this->request->getSession()->id();
 
 		$map = (array)Configure::read('Feedback.authMap') + [
-				'username' => 'username',
-				'email' => 'email',
-			];
+			'username' => 'username',
+			'email' => 'email',
+		];
 		if ($this->components()->has('AuthUser')) {
 			$username = $this->AuthUser->user($userField) ?: $this->AuthUser->user('account') ?: '';
 			if (empty($data['name']) || Configure::read('Feedback.forceauthusername')) {

--- a/src/Controller/FeedbackController.php
+++ b/src/Controller/FeedbackController.php
@@ -65,12 +65,14 @@ class FeedbackController extends AppController {
 		$userField = $map['username'];
 		$emailField = $map['email'];
 
+		$sessionKey = Configure::read('Feedback.sessionKey') ?? 'Auth.User';
+
 		if ($this->components()->has('AuthUser')) {
 			$name = $this->AuthUser->user($userField) ?: $this->AuthUser->user('account') ?: '';
 			$email = $this->AuthUser->user($emailField) ?: $this->AuthUser->user('email') ?: '';
 		} else {
-			$name = $this->request->getSession()->read($userField) ?: $this->request->getSession()->read('Auth.User.username') ?: '';
-			$email = $this->request->getSession()->read($emailField) ?: $this->request->getSession()->read('Auth.User.email') ?: '';
+			$name = $this->request->getSession()->read($userField) ?: $this->request->getSession()->read($sessionKey . '.username') ?: '';
+			$email = $this->request->getSession()->read($emailField) ?: $this->request->getSession()->read($sessionKey . '.email') ?: '';
 		}
 
 		$data = (array)$this->request->getData() + [

--- a/src/Store/Priorities.php
+++ b/src/Store/Priorities.php
@@ -30,7 +30,7 @@ class Priorities {
 
 		$array = [
 			'' => __d('feedback', ' - no priority - '),
- 		];
+		];
 		foreach ($priorities as $priority => $label) {
 			$array[$priority] = __d('feedback', $label);
 		}

--- a/tests/TestCase/Generator/StoreCollectionTest.php
+++ b/tests/TestCase/Generator/StoreCollectionTest.php
@@ -26,8 +26,7 @@ class StoreCollectionTest extends TestCase {
 	 * @return void
 	 */
 	public function testCollectInvalid() {
-		$data = [
-		];
+		$data = [];
 		$result = $this->storeCollection->save($data);
 
 		$expected = [

--- a/tests/TestCase/Store/DatabaseStoreTest.php
+++ b/tests/TestCase/Store/DatabaseStoreTest.php
@@ -32,8 +32,7 @@ class DatabaseStoreTest extends TestCase {
 	 * @return void
 	 */
 	public function testSaveInvalid() {
-		$data = [
-		];
+		$data = [];
 		$result = $this->store->save($data);
 
 		$expected = [


### PR DESCRIPTION
## Summary

Adds configurable `sessionKey` for compatibility with CakeDC/Users and the modern CakePHP Authentication plugin.

By default, the plugin looks for user identity under `Auth.User` session key (legacy CakePHP Auth).
CakeDC/Users and the Authentication plugin store identity under `Auth` directly.

## Configuration

Add to `config/app.php`:

```php
'Feedback' => [
    'sessionKey' => 'Auth', // For CakeDC/Users or Authentication plugin
    // 'sessionKey' => 'Auth.User', // Default (legacy Auth)
],
```

## Test plan

- [ ] Verify username/email are correctly read with default `Auth.User` session key
- [ ] Verify username/email are correctly read with `Auth` session key (CakeDC/Users)