### PR TITLE
Make admin UI and sidebar widget CSP-compatible

### DIFF
--- a/templates/Admin/Feedback/listing.php
+++ b/templates/Admin/Feedback/listing.php
@@ -5,6 +5,8 @@
  */
 
 use Cake\Core\Configure;
+
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
 <div class="feedback index content large-9 medium-8 columns col-sm-8 col-12">
@@ -21,7 +23,13 @@ foreach ($feedbacks as $feedback) {
 	</a>
 	<div class="media-body">
 		<div class="pull-right float-right">
-			<?php echo $this->Form->postLink('Remove', ['action' => 'remove', $feedback['filename']], ['confirm' => 'Sure?']); ?>
+			<?php echo $this->Form->postButton('Remove', ['action' => 'remove', $feedback['filename']], [
+				'class' => 'btn btn-link p-0 align-baseline',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => 'Sure?',
+				],
+			]); ?>
 		</div>
 
 		<h4 class="media-heading"><?php echo $feedback['subject'] . ' <i>(' . date('d-m-Y H:i:s',$feedback['time']) . ')</i>';?></h4>
@@ -55,3 +63,12 @@ foreach ($feedbacks as $feedback) {
 ?>
 
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+	form.addEventListener('submit', function(e) {
+		if (!confirm(this.dataset.confirmMessage)) {
+			e.preventDefault();
+		}
+	});
+});
+</script>

--- a/templates/Admin/FeedbackItems/edit.php
+++ b/templates/Admin/FeedbackItems/edit.php
@@ -3,15 +3,22 @@
  * @var \App\View\AppView $this
  * @var \Feedback\Model\Entity\FeedbackItem $feedbackItem
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
 	<aside class="column large-3 medium-4 columns col-sm-4 col-12">
 		<ul class="side-nav nav nav-pills flex-column">
 			<li class="nav-item heading"><?= __('Actions') ?></li>
-			<li class="nav-item"><?= $this->Form->postLink(
+			<li class="nav-item"><?= $this->Form->postButton(
 				__('Delete'),
 				['action' => 'delete', $feedbackItem->id],
-				['confirm' => __('Are you sure you want to delete # {0}?', $feedbackItem->id), 'class' => 'side-nav-item']
+				[
+					'class' => 'side-nav-item btn btn-link text-start w-100',
+					'form' => [
+						'class' => 'd-inline',
+						'data-confirm-message' => __('Are you sure you want to delete # {0}?', $feedbackItem->id),
+					],
+				]
 				) ?></li>
 			<li class="nav-item"><?= $this->Html->link(__('List Feedback Items'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
 		</ul>
@@ -38,3 +45,12 @@
 		</div>
 	</div>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+	form.addEventListener('submit', function(e) {
+		if (!confirm(this.dataset.confirmMessage)) {
+			e.preventDefault();
+		}
+	});
+});
+</script>

--- a/templates/Admin/FeedbackItems/index.php
+++ b/templates/Admin/FeedbackItems/index.php
@@ -7,6 +7,7 @@
 use Cake\Core\Configure;
 use Cake\Core\Plugin;
 
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
 	<ul class="side-nav nav nav-pills flex-column">
@@ -14,7 +15,13 @@ use Cake\Core\Plugin;
 		<li class="nav-item">
 			<?= $this->Html->link(__('Back'), ['controller' => 'Feedback', 'action' => 'index'], ['class' => 'nav-link']) ?>
 			<?php if (Configure::read('Feedback.configuration.Filesystem.location')) {
-			echo $this->Form->postLink(__('Import Files'), ['action' => 'importFiles'], ['class' => 'nav-link', 'confirm' => 'Sure?']);
+			echo $this->Form->postButton(__('Import Files'), ['action' => 'importFiles'], [
+				'class' => 'nav-link btn btn-link text-start w-100',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => 'Sure?',
+				],
+			]);
 			} ?>
 		</li>
 	</ul>
@@ -52,7 +59,14 @@ use Cake\Core\Plugin;
 					<td class="actions">
 						<?php echo $this->Html->link(isset($this->Icon) ? $this->Icon->render('view') : __('View'), ['action' => 'view', $feedbackItem->id], ['escapeTitle' => false]); ?>
 						<?php echo $this->Html->link(isset($this->Icon) ? $this->Icon->render('edit') : __('Edit'), ['action' => 'edit', $feedbackItem->id], ['escapeTitle' => false]); ?>
-						<?php echo $this->Form->postLink(isset($this->Icon) ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $feedbackItem->id], ['escapeTitle' => false, 'confirm' => __('Are you sure you want to delete # {0}?', $feedbackItem->id)]); ?>
+						<?php echo $this->Form->postButton(isset($this->Icon) ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $feedbackItem->id], [
+							'escapeTitle' => false,
+							'class' => 'btn btn-link p-0 align-baseline',
+							'form' => [
+								'class' => 'd-inline',
+								'data-confirm-message' => __('Are you sure you want to delete # {0}?', $feedbackItem->id),
+							],
+						]); ?>
 					</td>
 				</tr>
 				<?php endforeach; ?>
@@ -68,3 +82,12 @@ use Cake\Core\Plugin;
 	}
 	?>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+	form.addEventListener('submit', function(e) {
+		if (!confirm(this.dataset.confirmMessage)) {
+			e.preventDefault();
+		}
+	});
+});
+</script>

--- a/templates/Admin/FeedbackItems/view.php
+++ b/templates/Admin/FeedbackItems/view.php
@@ -3,13 +3,20 @@
  * @var \App\View\AppView $this
  * @var \Feedback\Model\Entity\FeedbackItem $feedbackItem
  */
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <div class="row">
 	<aside class="column actions large-3 medium-4 col-sm-4 col-xs-12">
 		<ul class="side-nav nav nav-pills flex-column">
 			<li class="nav-item heading"><?= __('Actions') ?></li>
 			<li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('Feedback Item')), ['action' => 'edit', $feedbackItem->id], ['class' => 'side-nav-item']) ?></li>
-			<li class="nav-item"><?= $this->Form->postLink(__('Delete {0}', __('Feedback Item')), ['action' => 'delete', $feedbackItem->id], ['confirm' => __('Are you sure you want to delete # {0}?', $feedbackItem->id), 'class' => 'side-nav-item']) ?></li>
+			<li class="nav-item"><?= $this->Form->postButton(__('Delete {0}', __('Feedback Item')), ['action' => 'delete', $feedbackItem->id], [
+				'class' => 'side-nav-item btn btn-link text-start w-100',
+				'form' => [
+					'class' => 'd-inline',
+					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $feedbackItem->id),
+				],
+			]) ?></li>
 			<li class="nav-item"><?= $this->Html->link(__('List {0}', __('Feedback Items')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
 		</ul>
 	</aside>
@@ -30,7 +37,14 @@
 					}
 					$class = array_shift($classes) ?: 'default';
 
-					echo $this->Form->postLink($value, ['action' => 'edit', $feedbackItem->id], ['data' => ['status' => $key], 'class' => 'btn btn-' . $class, 'confirm' => 'Sure?']);
+					echo $this->Form->postButton($value, ['action' => 'edit', $feedbackItem->id], [
+						'data' => ['status' => $key],
+						'class' => 'btn btn-' . $class,
+						'form' => [
+							'class' => 'd-inline',
+							'data-confirm-message' => 'Sure?',
+						],
+					]);
 					?>
 				<?php } ?>
 			<?php } ?>
@@ -98,3 +112,12 @@
 		</div>
 	</div>
 </div>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
+document.querySelectorAll('form[data-confirm-message]').forEach(function(form) {
+	form.addEventListener('submit', function(e) {
+		if (!confirm(this.dataset.confirmMessage)) {
+			e.preventDefault();
+		}
+	});
+});
+</script>

--- a/templates/element/sidebar.php
+++ b/templates/element/sidebar.php
@@ -63,12 +63,23 @@ if ($this->helpers()->has('AuthUser')) {
 		$email = $this->request->getSession()->read($map['email']);
 	}
 }
+$cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 
-<script>
+<script<?= $cspNonce !== '' ? ' nonce="' . h($cspNonce) . '"' : '' ?>>
 	//Create URL using cake's url helper, this is used in feedbackit-functions.js
 	<?php $formUrl = $this->Url->build(['prefix' => false, 'plugin' => 'Feedback', 'controller' => 'Feedback', 'action' => 'save'], ['fullBase' => true]); ?>
 	window.formURL = '<?php echo $formUrl; ?>';
+	// Neutralize clicks on the feedback widget's inert link/buttons (CSP-safe
+	// replacement for inline onclick="return false;"). These elements are
+	// managed by feedbackit-functions.js; here we just prevent default
+	// navigation/submission when they are clicked.
+	document.addEventListener('click', function(e) {
+		var target = e.target.closest('[data-feedback-nop]');
+		if (target) {
+			e.preventDefault();
+		}
+	});
 </script>
 
 <div id="feedbackit-slideout">
@@ -138,10 +149,10 @@ if ($this->helpers()->has('AuthUser')) {
 			<div class="form-group">
 				<p>
 					<button
+						type="button"
 						class="btn btn-info"
 						data-loading-text="<?php echo __d('feedback','Click anywhere on website'); ?>"
-						id="feedbackit-highlight"
-						onclick="return false;">
+						id="feedbackit-highlight">
 						<i class="icon-screenshot icon-white"></i><span class="icon <?php echo $icons['screenshot']; ?>"></span> <?php echo __d('feedback','Highlight something'); ?>
 					</button>
 				</p>
@@ -159,7 +170,7 @@ if ($this->helpers()->has('AuthUser')) {
 								?>
 							>
 						<?php
-						$confirmation = '<b><a id="feedbackit-okay-message" href="#" onclick="return false;" data-toggle="tooltip" title="' . h($termstext) . '">'. __d('feedback','this'). '</a></b>';
+						$confirmation = '<b><a id="feedbackit-okay-message" href="#" data-feedback-nop="1" data-toggle="tooltip" title="' . h($termstext) . '">'. __d('feedback','this'). '</a></b>';
 						?>
 						<?php echo __d('feedback','I am okay with {0}.', $confirmation); ?>
 					</label>
@@ -179,7 +190,7 @@ if ($this->helpers()->has('AuthUser')) {
 
 				<div class="btn-group">
 					<button class="btn btn-success" id="feedbackit-submit" disabled="disabled" type="submit"><i class="icon-envelope icon-white"></i><span class="icon <?php echo $icons['submit']; ?>"></span> <?php echo __d('feedback','Submit'); ?></button>
-					<button class="btn btn-danger" id="feedbackit-cancel" onclick="return false;"><i class="icon-remove icon-white"></i><span class="icon <?php echo $icons['cancel']; ?>"></span> <?php echo __d('feedback','Cancel'); ?></button>
+					<button type="button" class="btn btn-danger" id="feedbackit-cancel"><i class="icon-remove icon-white"></i><span class="icon <?php echo $icons['cancel']; ?>"></span> <?php echo __d('feedback','Cancel'); ?></button>
 				</div>
 			</div>
 		</form>


### PR DESCRIPTION
## Summary

- Replace 6 `Form->postLink` + `confirm` calls in admin templates with `Form->postButton` + `data-confirm-message`.
- Add nonce to inline `<script>` blocks in admin templates and in the frontend sidebar widget.
- Replace 3 inline `onclick="return false;"` handlers in `templates/element/sidebar.php` with CSP-safe equivalents (`type="button"` where appropriate, and `data-feedback-nop` + delegated click listener for the inert anchor).

## Motivation

Under a strict Content-Security-Policy with `script-src 'self' 'nonce-...'`, inline `<script>` blocks without `nonce` and inline event handlers (`onclick=`, etc.) are blocked by the browser. Per the CSP spec, the `nonce` keyword applies ONLY to inline `<script>` / `<style>` blocks — not to event-handler attributes. `$this->Form->postLink(...)` emits `onclick="document.post_X.submit(); ..."` and is therefore unsafe under strict CSP.

## Changes

- **Frontend sidebar (`templates/element/sidebar.php`)**:
  - `<button id="feedbackit-highlight" onclick="return false;">` -> `type="button"` (no submit, no inline handler needed).
  - `<button id="feedbackit-cancel" onclick="return false;">` -> `type="button"`.
  - `<a id="feedbackit-okay-message" href="#" onclick="return false;">` -> `href="#" data-feedback-nop="1"` plus a delegated click listener that calls `preventDefault`.
  - Add `nonce` to the existing inline `<script>` block (which also registers the delegate).

- **Admin templates**: replace 6 `Form->postLink` calls (`edit.php`, `view.php` x2, `index.php` x2, `listing.php`) with `Form->postButton` (preserves the confirmation UX via `form[data-confirm-message]` + a JS delegate). Add nonce-aware inline `<script>` blocks with the delegate to each admin template that uses it (4 scripts total).

The plugin has no dedicated layout, so the delegate lives in the individual templates that render `postButton` forms.

## Host app nonce setup

Apps that want to benefit need to set a `cspNonce` request attribute in a middleware, e.g.:

```php
$nonce = base64_encode(random_bytes(16));
$request = $request->withAttribute('cspNonce', $nonce);
$response = $response->withHeader(
    'Content-Security-Policy',
    "script-src 'self' 'nonce-{$nonce}'"
);
```

If no `cspNonce` attribute is present, the `<script>` tag falls back to rendering without `nonce` — apps on permissive CSP continue to work unchanged.

## Before / after

```diff
- <button class="btn btn-info" id="feedbackit-highlight" onclick="return false;">
+ <button type="button" class="btn btn-info" id="feedbackit-highlight">
```

```diff
- <?= $this->Form->postLink('Delete', [...], ['confirm' => 'Sure?']) ?>
+ <?= $this->Form->postButton('Delete', [...], [
+     'class' => 'btn btn-link',
+     'form' => [
+         'class' => 'd-inline',
+         'data-confirm-message' => 'Sure?',
+     ],
+ ]) ?>
```
