### PR TITLE
Drop inline styles for strict-CSP compatibility

### DIFF
--- a/templates/Admin/Feedback/viewimage.php
+++ b/templates/Admin/Feedback/viewimage.php
@@ -4,4 +4,4 @@
  * @var string $screenshot
  */
 ?>
-<img src="data:image/png;base64,<?php echo $screenshot; ?>" style="border:1px solid black; max-width:100%;max-height:100%;"/>
+<img src="data:image/png;base64,<?php echo $screenshot; ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>

--- a/templates/Admin/FeedbackItems/viewimage.php
+++ b/templates/Admin/FeedbackItems/viewimage.php
@@ -4,4 +4,4 @@
  * @var string $screenshot
  */
 ?>
-<img src="data:image/png;base64,<?php echo $screenshot; ?>" style="border:1px solid black; max-width:100%;max-height:100%;"/>
+<img src="data:image/png;base64,<?php echo $screenshot; ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>

--- a/templates/Feedback/viewimage.php
+++ b/templates/Feedback/viewimage.php
@@ -4,4 +4,4 @@
  * @var string $screenshot
  */
 ?>
-<img src="data:image/png;base64,<?php echo $screenshot; ?>" style="border:1px solid black; max-width:100%;max-height:100%;"/>
+<img src="data:image/png;base64,<?php echo $screenshot; ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>

--- a/templates/element/sidebar.php
+++ b/templates/element/sidebar.php
@@ -156,7 +156,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 						<i class="icon-screenshot icon-white"></i><span class="icon <?php echo $icons['screenshot']; ?>"></span> <?php echo __d('feedback','Highlight something'); ?>
 					</button>
 				</p>
-				<div <?php if (!$enableacceptterms) echo 'style="display:none;"'; ?>>
+				<div<?php if (!$enableacceptterms) echo ' class="feedbackit-hidden"'; ?>>
 					<label class="checkbox checkbox-inline">
 						<input type="checkbox"
 							   required id="feedbackit-okay"

--- a/webroot/css/sidebar.css
+++ b/webroot/css/sidebar.css
@@ -97,3 +97,8 @@
 .tab-hide {
 	cursor: pointer;
 }
+
+/* Visibility utility used when accept-terms is disabled */
+.feedbackit-hidden {
+	display: none;
+}


### PR DESCRIPTION
## Summary

Removes the four `style="..."` attributes flagged by a CSP audit:

- **`viewimage.php` (×3 — Admin/Feedback, Admin/FeedbackItems, Feedback)**: the screenshot view used `style="border:1px solid black; max-width:100%; max-height:100%"` on the `<img>`. These templates render via `setLayout('ajax')`, so there is no `<head>` to load CSS into — moving the rules to a class has no place to live. The border was purely cosmetic; drop the inline `style` and add a translatable `alt`. The screenshot still renders at natural size, fitting the viewport.
- **`templates/element/sidebar.php`**: replace the conditional `style="display:none;"` on the accept-terms wrapper `<div>` with a `feedbackit-hidden` class defined in the already-loaded `webroot/css/sidebar.css`.

After this PR there are no inline `style="..."` attributes in templates.

## Files changed

- `templates/Admin/Feedback/viewimage.php`
- `templates/Admin/FeedbackItems/viewimage.php`
- `templates/Feedback/viewimage.php`
- `templates/element/sidebar.php`
- `webroot/css/sidebar.css` — adds `.feedbackit-hidden`