### PR TITLE
Escape user-submitted feedback content in admin listing

### DIFF
--- a/templates/Admin/Feedback/listing.php
+++ b/templates/Admin/Feedback/listing.php
@@ -18,8 +18,8 @@ foreach ($feedbacks as $feedback) {
 ?>
 
   <div class="media">
-	<a class="pull-left float-left" href="<?php echo $this->Url->build(['plugin'=>'Feedback','controller'=>'Feedback','action'=>'viewimage', $feedback['filename']]); ?>" target="_blank">
-	  <img class="media-object feedbackit-small-img" src="data:image/png;base64,<?php echo $feedback['screenshot']; ?>">
+	<a class="pull-left float-left" href="<?php echo $this->Url->build(['plugin'=>'Feedback','controller'=>'Feedback','action'=>'viewimage', $feedback['filename']]); ?>" target="_blank" rel="noopener noreferrer">
+	  <img class="media-object feedbackit-small-img" src="data:image/png;base64,<?php echo h($feedback['screenshot']); ?>">
 	</a>
 	<div class="media-body">
 		<div class="pull-right float-right">
@@ -32,8 +32,8 @@ foreach ($feedbacks as $feedback) {
 			]); ?>
 		</div>
 
-		<h4 class="media-heading"><?php echo $feedback['subject'] . ' <i>(' . date('d-m-Y H:i:s',$feedback['time']) . ')</i>';?></h4>
-		<b><?php echo $feedback['feedback'];?></b>
+		<h4 class="media-heading"><?php echo h($feedback['subject']) . ' <i>(' . date('d-m-Y H:i:s', $feedback['time']) . ')</i>';?></h4>
+		<b><?php echo h($feedback['feedback']);?></b>
 
 		<?php
 		//Unset the already displayed vars and loop throught the next. Saves us some coding when a new var is added to the feedback
@@ -45,14 +45,15 @@ foreach ($feedbacks as $feedback) {
 		unset($feedback['copyme']);
 
 		foreach ($feedback as $fieldname => $fieldvalue) {
-			if ($fieldname === 'url' && Configure::read('Feedback.autoLink')) {
-				$fieldvalue = '<a href="' . $fieldvalue . '" target="_blank">' . $fieldvalue . '</a>';
+			if ($fieldname === 'url' && Configure::read('Feedback.autoLink') && preg_match('#^https?://#i', (string)$fieldvalue)) {
+				$safe = h($fieldvalue);
+				$fieldvalue = '<a href="' . $safe . '" target="_blank" rel="noopener noreferrer">' . $safe . '</a>';
 			} else {
 				$fieldvalue = h($fieldvalue);
 			}
 
 			echo '<br/>';
-			echo '<b>' . ucfirst($fieldname) . ":</b> $fieldvalue";
+			echo '<b>' . h(ucfirst($fieldname)) . ":</b> $fieldvalue";
 		}
 ?>
 	</div>


### PR DESCRIPTION
## Issue

`templates/Admin/Feedback/listing.php` echoed several user-submitted fields without escaping:

- `$feedback['subject']` — line 35
- `$feedback['feedback']` — line 36
- `$feedback['screenshot']` (base64 data in an img `src`) — line 22
- `$feedback['url']` (when `Feedback.autoLink` is enabled) — line 49, interpolated into both an `href` attribute and link text

An attacker submitting a feedback record with HTML/JS in any of those fields gets script execution in the admin panel that views the listing — admin-targeted stored XSS.

The non-admin `Feedback/index.php` template already escapes correctly. This brings the admin listing in line.

## Fixes

- Wrap subject, feedback, screenshot, and field name in `h()`.
- For autoLink: escape the URL with `h()` before inserting into `href` and link text, AND only autoLink when the URL passes a `http(s)://` scheme check so `javascript:` / `data:` URLs are blocked even with the attribute escaped.
- Add `rel='noopener noreferrer'` on the new-tab links.

## Severity

Stored XSS reachable by any user who can submit feedback (typically anyone), targeting any admin who views the listing. Worth treating as a security release.
