### PR TITLE
Escape user-controlled values in feedback templates

### DIFF
--- a/templates/Admin/Feedback/viewimage.php
+++ b/templates/Admin/Feedback/viewimage.php
@@ -4,4 +4,4 @@
  * @var string $screenshot
  */
 ?>
-<img src="data:image/png;base64,<?php echo $screenshot; ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>
+<img src="data:image/png;base64,<?php echo h($screenshot); ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>

--- a/templates/Admin/FeedbackItems/view.php
+++ b/templates/Admin/FeedbackItems/view.php
@@ -103,7 +103,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			<div class="screenshot">
 				<?php
 				if ($screenshot) {
-					$img = '<img class="screenshot responsive img-fluid" src="data:image/png;base64,' . $screenshot . '"/>';
+					$img = '<img class="screenshot responsive img-fluid" src="data:image/png;base64,' . h($screenshot) . '"/>';
 					echo $this->Html->link($img, ['plugin'=>'Feedback','controller'=>'FeedbackItems','action'=>'viewimage', $feedbackItem->id], ['escapeTitle' => false, 'target' => '_blank']);
 				}
 				?>

--- a/templates/Admin/FeedbackItems/viewimage.php
+++ b/templates/Admin/FeedbackItems/viewimage.php
@@ -4,4 +4,4 @@
  * @var string $screenshot
  */
 ?>
-<img src="data:image/png;base64,<?php echo $screenshot; ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>
+<img src="data:image/png;base64,<?php echo h($screenshot); ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>

--- a/templates/Feedback/index.php
+++ b/templates/Feedback/index.php
@@ -9,7 +9,7 @@ foreach ($feedbacks as $feedback) {
 
   <div class="media">
 	<a class="pull-left float-left" href="<?php echo $this->Url->build(['plugin'=>'Feedback','controller'=>'Feedback','action'=>'viewimage', $feedback['filename']]); ?>" target="_blank">
-	  <img class="media-object feedbackit-small-img" src="data:image/png;base64,<?php echo $feedback['screenshot']; ?>">
+	  <img class="media-object feedbackit-small-img" src="data:image/png;base64,<?php echo h($feedback['screenshot']); ?>">
 	</a>
 	<div class="media-body">
 	  <h4 class="media-heading"><?php echo h($feedback['subject']) . ' <i>(' . date('d-m-Y H:i:s', $feedback['time']) . ')</i>';?></h4>

--- a/templates/Feedback/viewimage.php
+++ b/templates/Feedback/viewimage.php
@@ -4,4 +4,4 @@
  * @var string $screenshot
  */
 ?>
-<img src="data:image/png;base64,<?php echo $screenshot; ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>
+<img src="data:image/png;base64,<?php echo h($screenshot); ?>" alt="<?php echo __d('feedback', 'Screenshot'); ?>"/>

--- a/templates/element/sidebar.php
+++ b/templates/element/sidebar.php
@@ -102,7 +102,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					id="feedbackit-name"
 					maxlength="150"
 					class="<?php if (!empty($name)) echo 'feedbackit-input'; ?> form-control"
-					value="<?php echo $name; ?>"
+					value="<?php echo h($name); ?>"
 					placeholder="<?php echo __d('feedback','Your name '); if( !$forceauthusername ) echo ' (optional)'; ?>"
 					<?php if ($forceauthusername) echo 'required="required"'; ?>
 					>
@@ -117,7 +117,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					id="feedbackit-email"
 					maxlength="150"
 					class="<?php if (!empty($email)) echo 'feedbackit-input'; ?> form-control"
-					value="<?php echo $email; ?>"
+					value="<?php echo h($email); ?>"
 					placeholder="<?php echo __d('feedback','Your e-mail'); if( !$forceemail) echo ' (optional)'; ?>"
 					<?php if ($forceemail) echo 'required="required"'; ?>
 					>


### PR DESCRIPTION
## Summary

- Escape `$name` and `$email` in `templates/element/sidebar.php` value attributes — they are sourced from the active session / `AuthUser` map and any upstream component that lets an attacker influence those keys (e.g. an OAuth display name) reaches every page that renders the widget unescaped.
- Escape stored screenshot bytes echoed into `data:` URIs in `templates/Feedback/index.php`, `templates/Feedback/viewimage.php`, `templates/Admin/Feedback/viewimage.php`, `templates/Admin/FeedbackItems/viewimage.php`, and `templates/Admin/FeedbackItems/view.php`. A submitter who replaces the legitimate base64 payload with attribute-breaking content otherwise persists XSS for every user or admin who opens the feedback item.
- Mirrors the already-escaped admin listing template; net change is six `h()` wraps.