### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/feedback.pot
+++ b/resources/locales/feedback.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
-"POT-Creation-Date: 2018-01-16 14:00+0000\n"
+"POT-Creation-Date: 2026-05-04 04:19+0200\n"
 "PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
 "Last-Translator: NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -14,104 +14,171 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: Controller/FeedbackController.php:59
+msgid "The feedback item has been saved."
+msgstr ""
+
+msgid "The feedback item could not be saved. Please, try again."
+msgstr ""
+
+msgid "The feedback item has been deleted."
+msgstr ""
+
+msgid "The feedback item could not be deleted. Please, try again."
+msgstr ""
+
 msgid "Anonymous"
 msgstr ""
 
-#: Controller/FeedbackController.php:81
 msgid "Error saving feedback."
 msgstr ""
 
-#: Controller/FeedbackController.php:85
 msgid "Your feedback was saved successfully."
 msgstr ""
 
-#: Model/Table/FeedbackstoreTable.php:90;179;261;340;442;531
-#: Store/FilesystemStore.php:31
-msgid "Thank you. Your feedback was saved."
-msgstr ""
-
-#: Model/Table/FeedbackstoreTable.php:94;265;344;446;535
-#: Store/FilesystemStore.php:35
-msgid "View your feedback on:"
-msgstr ""
-
-#: Model/Table/FeedbackstoreTable.php:166
 msgid "A copy of your submitted feedback:"
 msgstr ""
 
-#: Template/Element/sidebar.ctp:35
-msgid "When you submit, a screenshot (of only this website) will be taken to aid us in processing your feedback or bugreport."
+msgid "Thank you. Your feedback was saved."
 msgstr ""
 
-#: Template/Element/sidebar.ctp:59
-msgid "Hide this tab completely."
+msgid "View your feedback on:"
 msgstr ""
 
-#: Template/Element/sidebar.ctp:61
-msgid "Send your feedback or bugreport!"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:71
-msgid "Your name"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:82
-msgid "Your e-mail"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:93
-msgid "Subject"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:97
-msgid "Feedback or suggestion"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:103
-msgid "Click anywhere on website"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:106
-msgid "Highlight something"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:123
-msgid "this"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:125
-msgid "I am okay with {0}."
-msgstr ""
-
-#: Template/Element/sidebar.ctp:134
-msgid "E-mail me a copy"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:142
-msgid "Submit"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:143
-msgid "Cancel"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:158
-msgid "Feedback submitted"
-msgstr ""
-
-#: Template/Element/sidebar.ctp:164
-msgid "Close"
+msgid "View your feedback on: "
 msgstr ""
 
 msgid " - no priority - "
 msgstr ""
 
-msgid "low"
+msgid "Screenshot"
 msgstr ""
 
-msgid "medium"
+msgid "Actions"
 msgstr ""
 
-msgid "high"
+msgid "Delete"
 msgstr ""
+
+msgid "Are you sure you want to delete # {0}?"
+msgstr ""
+
+msgid "List Feedback Items"
+msgstr ""
+
+msgid "Feedback Items"
+msgstr ""
+
+msgid "Edit Feedback Item"
+msgstr ""
+
+msgid "Submit"
+msgstr ""
+
+msgid "Back"
+msgstr ""
+
+msgid "Import Files"
+msgstr ""
+
+msgid "View"
+msgstr ""
+
+msgid "Edit"
+msgstr ""
+
+msgid "Edit {0}"
+msgstr ""
+
+msgid "Feedback Item"
+msgstr ""
+
+msgid "Delete {0}"
+msgstr ""
+
+msgid "List {0}"
+msgstr ""
+
+msgid "Feedback"
+msgstr ""
+
+msgid "Sid"
+msgstr ""
+
+msgid "Url"
+msgstr ""
+
+msgid "Name"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "Subject"
+msgstr ""
+
+msgid "Data"
+msgstr ""
+
+msgid "Priority"
+msgstr ""
+
+msgid "Status"
+msgstr ""
+
+msgid "Created"
+msgstr ""
+
+msgid "first"
+msgstr ""
+
+msgid "previous"
+msgstr ""
+
+msgid "next"
+msgstr ""
+
+msgid "last"
+msgstr ""
+
+msgid "When you submit, a screenshot (of only this website) will be taken to aid us in processing your feedback or bugreport."
+msgstr ""
+
+msgid "Hide this tab completely."
+msgstr ""
+
+msgid "Send your feedback or bugreport!"
+msgstr ""
+
+msgid "Your name "
+msgstr ""
+
+msgid "Your e-mail"
+msgstr ""
+
+msgid "Feedback or suggestion"
+msgstr ""
+
+msgid "Click anywhere on website"
+msgstr ""
+
+msgid "Highlight something"
+msgstr ""
+
+msgid "this"
+msgstr ""
+
+msgid "I am okay with {0}."
+msgstr ""
+
+msgid "E-mail me a copy"
+msgstr ""
+
+msgid "Cancel"
+msgstr ""
+
+msgid "Feedback submitted"
+msgstr ""
+
+msgid "Close"
+msgstr ""
+

--- a/src/Controller/Admin/FeedbackItemsController.php
+++ b/src/Controller/Admin/FeedbackItemsController.php
@@ -95,11 +95,11 @@ class FeedbackItemsController extends AppController {
 		if ($this->request->is(['patch', 'post', 'put'])) {
 			$feedbackItem = $this->FeedbackItems->patchEntity($feedbackItem, $this->request->getData());
 			if ($this->FeedbackItems->save($feedbackItem)) {
-				$this->Flash->success(__('The feedback item has been saved.'));
+				$this->Flash->success(__d('feedback', 'The feedback item has been saved.'));
 
 				return $this->redirect(['action' => 'index']);
 			}
-			$this->Flash->error(__('The feedback item could not be saved. Please, try again.'));
+			$this->Flash->error(__d('feedback', 'The feedback item could not be saved. Please, try again.'));
 		}
 		$this->set(compact('feedbackItem'));
 	}
@@ -112,9 +112,9 @@ class FeedbackItemsController extends AppController {
 		$this->request->allowMethod(['post', 'delete']);
 		$feedbackItem = $this->FeedbackItems->get($id);
 		if ($this->FeedbackItems->delete($feedbackItem)) {
-			$this->Flash->success(__('The feedback item has been deleted.'));
+			$this->Flash->success(__d('feedback', 'The feedback item has been deleted.'));
 		} else {
-			$this->Flash->error(__('The feedback item could not be deleted. Please, try again.'));
+			$this->Flash->error(__d('feedback', 'The feedback item could not be deleted. Please, try again.'));
 		}
 
 		return $this->redirect(['action' => 'index']);

--- a/templates/Admin/FeedbackItems/edit.php
+++ b/templates/Admin/FeedbackItems/edit.php
@@ -8,29 +8,29 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 <div class="row">
 	<aside class="column large-3 medium-4 columns col-sm-4 col-12">
 		<ul class="side-nav nav nav-pills flex-column">
-			<li class="nav-item heading"><?= __('Actions') ?></li>
+			<li class="nav-item heading"><?= __d('feedback', 'Actions') ?></li>
 			<li class="nav-item"><?= $this->Form->postButton(
-				__('Delete'),
+				__d('feedback', 'Delete'),
 				['action' => 'delete', $feedbackItem->id],
 				[
 					'class' => 'side-nav-item btn btn-link text-start w-100',
 					'form' => [
 						'class' => 'd-inline',
-						'data-confirm-message' => __('Are you sure you want to delete # {0}?', $feedbackItem->id),
+						'data-confirm-message' => __d('feedback', 'Are you sure you want to delete # {0}?', $feedbackItem->id),
 					],
 				]
 				) ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('List Feedback Items'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
+			<li class="nav-item"><?= $this->Html->link(__d('feedback', 'List Feedback Items'), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
 		</ul>
 	</aside>
 	<div class="column-responsive column-80 form large-9 medium-8 columns col-sm-8 col-12">
 		<div class="feedbackItems form content">
-			<h1><?= __('Feedback Items') ?></h1>
+			<h1><?= __d('feedback', 'Feedback Items') ?></h1>
 
 			<h2><?php echo h($feedbackItem->url_short); ?></h2>
 			<?= $this->Form->create($feedbackItem) ?>
 			<fieldset>
-				<legend><?= __('Edit Feedback Item') ?></legend>
+				<legend><?= __d('feedback', 'Edit Feedback Item') ?></legend>
 				<?php
 					echo $this->Form->control('subject');
 					echo $this->Form->control('feedback');
@@ -40,7 +40,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					echo $this->Form->control('status', ['options' => $feedbackItem::statuses()]);
 				?>
 			</fieldset>
-			<?= $this->Form->button(__('Submit')) ?>
+			<?= $this->Form->button(__d('feedback', 'Submit')) ?>
 			<?= $this->Form->end() ?>
 		</div>
 	</div>

--- a/templates/Admin/FeedbackItems/index.php
+++ b/templates/Admin/FeedbackItems/index.php
@@ -11,11 +11,11 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 ?>
 <nav class="actions large-3 medium-4 columns col-sm-4 col-xs-12" id="actions-sidebar">
 	<ul class="side-nav nav nav-pills flex-column">
-		<li class="nav-item heading"><?= __('Actions') ?></li>
+		<li class="nav-item heading"><?= __d('feedback', 'Actions') ?></li>
 		<li class="nav-item">
-			<?= $this->Html->link(__('Back'), ['controller' => 'Feedback', 'action' => 'index'], ['class' => 'nav-link']) ?>
+			<?= $this->Html->link(__d('feedback', 'Back'), ['controller' => 'Feedback', 'action' => 'index'], ['class' => 'nav-link']) ?>
 			<?php if (Configure::read('Feedback.configuration.Filesystem.location')) {
-			echo $this->Form->postButton(__('Import Files'), ['action' => 'importFiles'], [
+			echo $this->Form->postButton(__d('feedback', 'Import Files'), ['action' => 'importFiles'], [
 				'class' => 'nav-link btn btn-link text-start w-100',
 				'form' => [
 					'class' => 'd-inline',
@@ -28,7 +28,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 </nav>
 <div class="feedbackItems index content large-9 medium-8 columns col-sm-8 col-12">
 
-	<h1><?= __('Feedback Items') ?></h1>
+	<h1><?= __d('feedback', 'Feedback Items') ?></h1>
 
 	<div class="">
 		<table class="table table-sm table-striped">
@@ -39,7 +39,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					<th><?= $this->Paginator->sort('subject') ?></th>
 					<th><?= $this->Paginator->sort('email') ?></th>
 					<th><?= $this->Paginator->sort('created', null, ['direction' => 'desc']) ?></th>
-					<th class="actions"><?= __('Actions') ?></th>
+					<th class="actions"><?= __d('feedback', 'Actions') ?></th>
 				</tr>
 			</thead>
 			<tbody>
@@ -57,14 +57,14 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 					</td>
 					<td><?= $this->Time->nice($feedbackItem->created) ?></td>
 					<td class="actions">
-						<?php echo $this->Html->link(isset($this->Icon) ? $this->Icon->render('view') : __('View'), ['action' => 'view', $feedbackItem->id], ['escapeTitle' => false]); ?>
-						<?php echo $this->Html->link(isset($this->Icon) ? $this->Icon->render('edit') : __('Edit'), ['action' => 'edit', $feedbackItem->id], ['escapeTitle' => false]); ?>
-						<?php echo $this->Form->postButton(isset($this->Icon) ? $this->Icon->render('delete') : __('Delete'), ['action' => 'delete', $feedbackItem->id], [
+						<?php echo $this->Html->link(isset($this->Icon) ? $this->Icon->render('view') : __d('feedback', 'View'), ['action' => 'view', $feedbackItem->id], ['escapeTitle' => false]); ?>
+						<?php echo $this->Html->link(isset($this->Icon) ? $this->Icon->render('edit') : __d('feedback', 'Edit'), ['action' => 'edit', $feedbackItem->id], ['escapeTitle' => false]); ?>
+						<?php echo $this->Form->postButton(isset($this->Icon) ? $this->Icon->render('delete') : __d('feedback', 'Delete'), ['action' => 'delete', $feedbackItem->id], [
 							'escapeTitle' => false,
 							'class' => 'btn btn-link p-0 align-baseline',
 							'form' => [
 								'class' => 'd-inline',
-								'data-confirm-message' => __('Are you sure you want to delete # {0}?', $feedbackItem->id),
+								'data-confirm-message' => __d('feedback', 'Are you sure you want to delete # {0}?', $feedbackItem->id),
 							],
 						]); ?>
 					</td>

--- a/templates/Admin/FeedbackItems/view.php
+++ b/templates/Admin/FeedbackItems/view.php
@@ -8,16 +8,16 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 <div class="row">
 	<aside class="column actions large-3 medium-4 col-sm-4 col-xs-12">
 		<ul class="side-nav nav nav-pills flex-column">
-			<li class="nav-item heading"><?= __('Actions') ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('Edit {0}', __('Feedback Item')), ['action' => 'edit', $feedbackItem->id], ['class' => 'side-nav-item']) ?></li>
-			<li class="nav-item"><?= $this->Form->postButton(__('Delete {0}', __('Feedback Item')), ['action' => 'delete', $feedbackItem->id], [
+			<li class="nav-item heading"><?= __d('feedback', 'Actions') ?></li>
+			<li class="nav-item"><?= $this->Html->link(__d('feedback', 'Edit {0}', __d('feedback', 'Feedback Item')), ['action' => 'edit', $feedbackItem->id], ['class' => 'side-nav-item']) ?></li>
+			<li class="nav-item"><?= $this->Form->postButton(__d('feedback', 'Delete {0}', __d('feedback', 'Feedback Item')), ['action' => 'delete', $feedbackItem->id], [
 				'class' => 'side-nav-item btn btn-link text-start w-100',
 				'form' => [
 					'class' => 'd-inline',
-					'data-confirm-message' => __('Are you sure you want to delete # {0}?', $feedbackItem->id),
+					'data-confirm-message' => __d('feedback', 'Are you sure you want to delete # {0}?', $feedbackItem->id),
 				],
 			]) ?></li>
-			<li class="nav-item"><?= $this->Html->link(__('List {0}', __('Feedback Items')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
+			<li class="nav-item"><?= $this->Html->link(__d('feedback', 'List {0}', __d('feedback', 'Feedback Items')), ['action' => 'index'], ['class' => 'side-nav-item']) ?></li>
 		</ul>
 	</aside>
 	<div class="column-responsive column-80 content large-9 medium-8 col-sm-8 col-xs-12">
@@ -55,7 +55,7 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 			?>
 
 			<div class="text">
-				<strong><?= __('Feedback') ?></strong>
+				<strong><?= __d('feedback', 'Feedback') ?></strong>
 				<blockquote>
 					<?= $this->Text->autoParagraph(h($feedbackItem->feedback)); ?>
 				</blockquote>
@@ -63,39 +63,39 @@ $cspNonce = (string)$this->getRequest()->getAttribute('cspNonce', '');
 
 			<table class="table table-striped">
 				<tr>
-					<th><?= __('Sid') ?></th>
+					<th><?= __d('feedback', 'Sid') ?></th>
 					<td><?= h($feedbackItem->sid) ?></td>
 				</tr>
 				<tr>
-					<th><?= __('Url') ?></th>
+					<th><?= __d('feedback', 'Url') ?></th>
 					<td><?= $this->Html->link($feedbackItem->url_short, $feedbackItem->url) ?></td>
 				</tr>
 				<tr>
-					<th><?= __('Name') ?></th>
+					<th><?= __d('feedback', 'Name') ?></th>
 					<td><?= h($feedbackItem->name) ?></td>
 				</tr>
 				<tr>
-					<th><?= __('Email') ?></th>
+					<th><?= __d('feedback', 'Email') ?></th>
 					<td><?= h($feedbackItem->email) ?></td>
 				</tr>
 				<tr>
-					<th><?= __('Subject') ?></th>
+					<th><?= __d('feedback', 'Subject') ?></th>
 					<td><?= h($feedbackItem->subject) ?></td>
 				</tr>
 				<tr>
-					<th><?= __('Data') ?></th>
+					<th><?= __d('feedback', 'Data') ?></th>
 					<td><pre><?= print_r(h($feedbackItem->data), true); ?></pre></td>
 				</tr>
 				<tr>
-					<th><?= __('Priority') ?></th>
+					<th><?= __d('feedback', 'Priority') ?></th>
 					<td><?= $feedbackItem->priority ? $feedbackItem::priorities($feedbackItem->priority) : '' ?></td>
 				</tr>
 				<tr>
-					<th><?= __('Status') ?></th>
+					<th><?= __d('feedback', 'Status') ?></th>
 					<td><?= $feedbackItem->status !== null ? $feedbackItem::statuses($feedbackItem->status) : '' ?></td>
 				</tr>
 				<tr>
-					<th><?= __('Created') ?></th>
+					<th><?= __d('feedback', 'Created') ?></th>
 					<td><?= $this->Time->nice($feedbackItem->created) ?></td>
 				</tr>
 			</table>

--- a/templates/element/pagination.php
+++ b/templates/element/pagination.php
@@ -5,11 +5,11 @@
 ?>
 <div class="paginator">
 	<ul class="pagination">
-		<?= $this->Paginator->first('<< ' . __('first')) ?>
-		<?= $this->Paginator->prev('< ' . __('previous')) ?>
+		<?= $this->Paginator->first('<< ' . __d('feedback', 'first')) ?>
+		<?= $this->Paginator->prev('< ' . __d('feedback', 'previous')) ?>
 		<?= $this->Paginator->numbers() ?>
-		<?= $this->Paginator->next(__('next') . ' >') ?>
-		<?= $this->Paginator->last(__('last') . ' >>') ?>
+		<?= $this->Paginator->next(__d('feedback', 'next') . ' >') ?>
+		<?= $this->Paginator->last(__d('feedback', 'last') . ' >>') ?>
 	</ul>
 	<p><?= $this->Paginator->counter('Page {{page}} of {{pages}}, showing {{current}} record(s) out of {{count}} total') ?></p>
 </div>


### PR DESCRIPTION
## Summary

- Convert 39 `__()` calls in `src/` and `templates/` to `__d('feedback', ...)`. The 41 pre-existing `__d('feedback', ...)` calls already pointed at the right domain — the rest of the plugin now matches.
- Refresh `resources/locales/feedback.pot` via `bin/cake i18n extract`. The POT was ~8 years stale (POT-Creation-Date 2018-01-16) and missed every string added in the admin backend since then. Went from ~25 to 56 unique msgids; also dropped per-string location comments by switching to `--no-location` so future regenerations stay tidy.

The existing `de/`, `es/`, `nl/`, `sv/` language packs are intentionally left untouched — translators can run `msgmerge` against the refreshed POT to pull in the new msgids without losing the existing translations.

## Why

Plugin strings were landing in the host app's `default` domain, plus the POT was so out of date that the admin UI was basically untranslatable even where the existing language packs already had relevant translations from older code paths.

## Verification (local)

- phpunit: 21 / 21
- phpstan: no errors
- phpcs: clean