### PR TITLE
Read tracker provider config from Feedback.configuration path

### DIFF
--- a/src/Model/Table/FeedbackstoreTable.php
+++ b/src/Model/Table/FeedbackstoreTable.php
@@ -43,18 +43,18 @@ class FeedbackstoreTable extends Table {
 		}
 
 		//Mandatory
-		$api_url	= Configure::read('Feedback.methods.mantis.api_url');
-		$username	= Configure::read('Feedback.methods.mantis.username');
-		$password	= Configure::read('Feedback.methods.mantis.password');
-		$project_id	= Configure::read('Feedback.methods.mantis.project_id');
-		$category	= Configure::read('Feedback.methods.mantis.category');
-		$decodeimage = Configure::read('Feedback.methods.mantis.decodeimage');
+		$api_url	= Configure::read('Feedback.configuration.mantis.api_url');
+		$username	= Configure::read('Feedback.configuration.mantis.username');
+		$password	= Configure::read('Feedback.configuration.mantis.password');
+		$project_id	= Configure::read('Feedback.configuration.mantis.project_id');
+		$category	= Configure::read('Feedback.configuration.mantis.category');
+		$decodeimage = Configure::read('Feedback.configuration.mantis.decodeimage');
 
 		//Optional HTTP credentials for bypassing Basic Auth or Kerberos
 		$soap_options = [];
 
-		$http_username = Configure::read('Feedback.methods.mantis.http_username');
-		$http_password = Configure::read('Feedback.methods.mantis.http_password');
+		$http_username = Configure::read('Feedback.configuration.mantis.http_username');
+		$http_password = Configure::read('Feedback.configuration.mantis.http_password');
 
 		if ($http_username && $http_password) {
 			$soap_options = [
@@ -140,8 +140,8 @@ class FeedbackstoreTable extends Table {
 		}
 
 		//Read settings from config if not in copy mode
-		$to = Configure::read('Feedback.methods.mail.to');
-		$from = Configure::read('Feedback.methods.mail.from');
+		$to = Configure::read('Feedback.configuration.mail.to');
+		$from = Configure::read('Feedback.configuration.mail.from');
 
 		// Change recipient if sending a copy
 		if ($copyreporter) {
@@ -220,10 +220,10 @@ class FeedbackstoreTable extends Table {
 		}
 
 		//Read settings
-		$api_url			= Configure::read('Feedback.methods.github.api_url');
-		$username			= Configure::read('Feedback.methods.github.username');
-		$password			= Configure::read('Feedback.methods.github.password');
-		$localimagestore = Configure::read('Feedback.methods.github.localimagestore');
+		$api_url			= Configure::read('Feedback.configuration.github.api_url');
+		$username			= Configure::read('Feedback.configuration.github.username');
+		$password			= Configure::read('Feedback.configuration.github.password');
+		$localimagestore = Configure::read('Feedback.configuration.github.localimagestore');
 
 		//Github specific: append browser, browser version and URL to feedback:
 		$feedbackObject['feedback'] .= "\n\n";
@@ -318,10 +318,10 @@ class FeedbackstoreTable extends Table {
 		}
 
 		//Read settings
-		$api_url			= Configure::read('Feedback.methods.bitbucket.api_url');
-		$username = Configure::read('Feedback.methods.bitbucket.username');
-		$password = Configure::read('Feedback.methods.bitbucket.password');
-		$localimagestore = Configure::read('Feedback.methods.bitbucket.localimagestore');
+		$api_url			= Configure::read('Feedback.configuration.bitbucket.api_url');
+		$username = Configure::read('Feedback.configuration.bitbucket.username');
+		$password = Configure::read('Feedback.configuration.bitbucket.password');
+		$localimagestore = Configure::read('Feedback.configuration.bitbucket.localimagestore');
 
 		//Append browser, browser version and URL to feedback:
 		$feedbackObject['feedback'] .= sprintf("**By**: %s\n\n", $feedbackObject['name']);
@@ -396,12 +396,12 @@ class FeedbackstoreTable extends Table {
 		}
 
 		//Read settings
-		$api_url			= Configure::read('Feedback.methods.jira.api_url');
-		$username			= Configure::read('Feedback.methods.jira.username');
-		$password			= Configure::read('Feedback.methods.jira.password');
-		$project_id			= Configure::read('Feedback.methods.jira.project_id');
-		$issuetype			= Configure::read('Feedback.methods.jira.issuetype');
-		$localimagestore = Configure::read('Feedback.methods.jira.localimagestore');
+		$api_url			= Configure::read('Feedback.configuration.jira.api_url');
+		$username			= Configure::read('Feedback.configuration.jira.username');
+		$password			= Configure::read('Feedback.configuration.jira.password');
+		$project_id			= Configure::read('Feedback.configuration.jira.project_id');
+		$issuetype			= Configure::read('Feedback.configuration.jira.issuetype');
+		$localimagestore = Configure::read('Feedback.configuration.jira.localimagestore');
 
 		//Mantis specific: append browser, browser version and URL to feedback:
 		$feedbackObject['feedback'] .= "\n\n";
@@ -498,11 +498,11 @@ class FeedbackstoreTable extends Table {
 		}
 
 		//Read settings
-		$api_url			= Configure::read('Feedback.methods.redmine.api_url');
-		$username			= Configure::read('Feedback.methods.redmine.username');
-		$password			= Configure::read('Feedback.methods.redmine.password');
-		$project_id			= Configure::read('Feedback.methods.redmine.project_id');
-		$tracker_id			= Configure::read('Feedback.methods.redmine.tracker_id');
+		$api_url			= Configure::read('Feedback.configuration.redmine.api_url');
+		$username			= Configure::read('Feedback.configuration.redmine.username');
+		$password			= Configure::read('Feedback.configuration.redmine.password');
+		$project_id			= Configure::read('Feedback.configuration.redmine.project_id');
+		$tracker_id			= Configure::read('Feedback.configuration.redmine.tracker_id');
 
 		//Redmine specific: append browser, browser version and URL to feedback:
 		$feedbackObject['feedback'] .= "\n\n";

--- a/tests/TestCase/Model/Table/FeedbackstoreTableTest.php
+++ b/tests/TestCase/Model/Table/FeedbackstoreTableTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types = 1);
+
+namespace Feedback\Test\TestCase\Model\Table;
+
+use Cake\Core\Configure;
+use Cake\Mailer\TransportFactory;
+use Cake\TestSuite\TestCase;
+use Feedback\Model\Table\FeedbackstoreTable;
+use TypeError;
+
+/**
+ * @uses \Feedback\Model\Table\FeedbackstoreTable
+ */
+class FeedbackstoreTableTest extends TestCase {
+
+	/**
+	 * @var \Feedback\Model\Table\FeedbackstoreTable
+	 */
+	protected $Feedbackstore;
+
+	/**
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		TransportFactory::drop('default');
+		TransportFactory::setConfig('default', [
+			'className' => 'Debug',
+		]);
+
+		$this->Feedbackstore = $this->getTableLocator()->get('Feedback.Feedbackstore', [
+			'className' => FeedbackstoreTable::class,
+		]);
+
+		Configure::delete('Feedback');
+	}
+
+	/**
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		TransportFactory::drop('default');
+		Configure::delete('Feedback');
+
+		// mail() writes a screenshot attachment to ROOT/tmp before sending; clean up any leftovers.
+		foreach (glob(ROOT . DS . 'tmp' . DS . '*.png') ?: [] as $tmpFile) {
+			unlink($tmpFile);
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The mail provider settings must be read from the documented `Feedback.configuration.mail.*`
+	 * path (the same path StoreCollection and the controllers use), not from `Feedback.methods.mail.*`.
+	 *
+	 * When `to`/`from` are read from the correct path, `Mailer::setTo()`/`setFrom()` receive valid
+	 * values and do not throw. If the values are read from the wrong path they resolve to null and
+	 * `setFrom(null)` throws a TypeError (array|string expected). So "no TypeError" proves the path.
+	 *
+	 * @return void
+	 */
+	public function testMailReadsConfigurationPath(): void {
+		Configure::write('Feedback.configuration.mail', [
+			'to' => 'target@example.com',
+			'from' => ['noreply@example.com' => 'FeedbackIt mailer'],
+		]);
+
+		$feedbackObject = $this->feedbackObject();
+
+		$threw = false;
+		try {
+			$this->Feedbackstore->mail($feedbackObject);
+		} catch (TypeError $e) {
+			$threw = true;
+		}
+
+		$this->assertFalse($threw, 'mail provider config was not read from Feedback.configuration.mail.*');
+	}
+
+	/**
+	 * Sanity check: without any config the recipient/sender are null and `setFrom(null)` throws,
+	 * which is exactly the failure users hit when their config sat under the documented
+	 * `configuration` path while the code only read the `methods` path.
+	 *
+	 * @return void
+	 */
+	public function testMailMissingConfigThrows(): void {
+		$feedbackObject = $this->feedbackObject();
+
+		$this->expectException(TypeError::class);
+		$this->Feedbackstore->mail($feedbackObject);
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	protected function feedbackObject(): array {
+		return [
+			'screenshot' => base64_encode('image-bytes'),
+			'subject' => 'A subject',
+			'feedback' => 'Some feedback body',
+			'browser' => 'Firefox',
+			'browser_version' => '1.0',
+			'url' => 'http://example.com',
+			'os' => 'Linux',
+			'name' => 'Reporter',
+			'email' => '',
+		];
+	}
+
+}


### PR DESCRIPTION
`FeedbackstoreTable` read every external-tracker provider config from `Feedback.methods.<provider>.*` (mantis, mail, github, bitbucket, jira, redmine), but the rest of the plugin — `StoreCollection`, the controllers — and the documented example config all use `Feedback.configuration.<provider>.*`. So provider settings placed under the documented `configuration` path resolved to `null` and were never applied.

This changes all provider reads in `FeedbackstoreTable` to the `Feedback.configuration.*` path (29 reads; the `methods` path was never documented or read by any other consumer — it was the bug, so no fallback is kept). A focused test on the `mail` provider proves the config is now read from the `configuration` path (it fails against the unfixed code and passes after).
