### PR TITLE
Use Mailer::deliver for raw feedback email content

### DIFF
--- a/src/Model/Table/FeedbackstoreTable.php
+++ b/src/Model/Table/FeedbackstoreTable.php
@@ -187,7 +187,7 @@ class FeedbackstoreTable extends Table {
 		$feedbackObject['feedback'] .= '<img src="cid:id-screenshot">'; //Add inline screenshot
 
 		try {
-			$email->send($feedbackObject['feedback']);
+			$email->deliver($feedbackObject['feedback']);
 			$returnobject['result'] = true;
 			$returnobject['msg'] = __d('feedback', 'Thank you. Your feedback was saved.');
 

--- a/tests/TestCase/Model/Table/FeedbackstoreTableTest.php
+++ b/tests/TestCase/Model/Table/FeedbackstoreTableTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Feedback\Test\TestCase\Model\Table;
 
 use Cake\Core\Configure;
+use Cake\Mailer\Mailer;
 use Cake\Mailer\TransportFactory;
 use Cake\TestSuite\TestCase;
 use Feedback\Model\Table\FeedbackstoreTable;
@@ -30,6 +31,13 @@ class FeedbackstoreTableTest extends TestCase {
 			'className' => 'Debug',
 		]);
 
+		// mail() instantiates a bare `new Mailer()`, which resolves the `default` mailer profile.
+		// Point that profile at the `default` (Debug) transport so deliver() has a transport to use.
+		Mailer::drop('default');
+		Mailer::setConfig('default', [
+			'transport' => 'default',
+		]);
+
 		$this->Feedbackstore = $this->getTableLocator()->get('Feedback.Feedbackstore', [
 			'className' => FeedbackstoreTable::class,
 		]);
@@ -42,6 +50,7 @@ class FeedbackstoreTableTest extends TestCase {
 	 */
 	protected function tearDown(): void {
 		TransportFactory::drop('default');
+		Mailer::drop('default');
 		Configure::delete('Feedback');
 
 		// mail() writes a screenshot attachment to ROOT/tmp before sending; clean up any leftovers.
@@ -78,6 +87,30 @@ class FeedbackstoreTableTest extends TestCase {
 		}
 
 		$this->assertFalse($threw, 'mail provider config was not read from Feedback.configuration.mail.*');
+	}
+
+	/**
+	 * Regression guard for the send/deliver bug.
+	 *
+	 * The raw HTML feedback body must be delivered via `Mailer::deliver()`. In CakePHP 5
+	 * `Mailer::send(?string $action)` treats a string argument as an action (mailer method)
+	 * name, so passing the HTML body throws MissingActionException. That exception is swallowed
+	 * by the surrounding try/catch (it only logs), so `mail()` would silently return result=false.
+	 *
+	 * BEFORE the fix: result is false (MissingActionException caught and logged).
+	 * AFTER the fix: result is true and the mail is delivered.
+	 *
+	 * @return void
+	 */
+	public function testMailDeliversRawContent(): void {
+		Configure::write('Feedback.configuration.mail', [
+			'to' => 'target@example.com',
+			'from' => ['noreply@example.com' => 'FeedbackIt mailer'],
+		]);
+
+		$result = $this->Feedbackstore->mail($this->feedbackObject());
+
+		$this->assertTrue($result['result']);
 	}
 
 	/**


### PR DESCRIPTION
`FeedbackstoreTable::mail()` calls `$email->send($feedbackObject['feedback'])` on a `Cake\Mailer\Mailer` instance. In CakePHP 5, `Mailer::send(?string $action = null, ...)` treats the string argument as a mailer *action* name, so passing the HTML body throws `MissingActionException`. That exception is swallowed by the surrounding `catch (Exception $e)` (logged as "Feedback could not be stored"), so the "email a copy to the reporter" path (`FeedbackController::add()` → `$this->Feedbackstore->mail($data, true)`) silently fails for every submission.

This uses `Mailer::deliver()`, the correct API for sending raw content. A regression test (with a test email transport) asserts `mail()` now returns `result === true`; it fails against the unfixed `send()` call and passes after.

Note: there is a separate, pre-existing minor bug in the same method — the success path `return`s before `unlink($tmpfile)`, leaking the temporary screenshot file. Left out to keep this change focused; can follow up separately.
