### PR TITLE
Remove temporary screenshot file after sending feedback mail

### DIFF
--- a/src/Model/Table/FeedbackstoreTable.php
+++ b/src/Model/Table/FeedbackstoreTable.php
@@ -190,14 +190,12 @@ class FeedbackstoreTable extends Table {
 			$email->deliver($feedbackObject['feedback']);
 			$returnobject['result'] = true;
 			$returnobject['msg'] = __d('feedback', 'Thank you. Your feedback was saved.');
-
-			return $returnobject;
 		} catch (Exception $e) {
 			// Something went wrong, lets try to log it
 			Log::write('error', 'Feedback could not be stored (' . $e->getMessage() . '): ' . json_encode($feedbackObject));
+		} finally {
+			unlink($tmpfile);
 		}
-
-		unlink($tmpfile);
 
 		return $returnobject;
 	}

--- a/tests/TestCase/Model/Table/FeedbackstoreTableTest.php
+++ b/tests/TestCase/Model/Table/FeedbackstoreTableTest.php
@@ -128,6 +128,27 @@ class FeedbackstoreTableTest extends TestCase {
 	}
 
 	/**
+	 * The temporary screenshot attachment written to ROOT/tmp must be removed after mail()
+	 * runs, including on the success path (which previously returned before unlink()).
+	 *
+	 * @return void
+	 */
+	public function testMailRemovesTempAttachmentFile(): void {
+		Configure::write('Feedback.configuration.mail', [
+			'to' => 'target@example.com',
+			'from' => ['noreply@example.com' => 'FeedbackIt mailer'],
+		]);
+
+		$pattern = ROOT . DS . 'tmp' . DS . '*.png';
+		$before = count(glob($pattern) ?: []);
+
+		$result = $this->Feedbackstore->mail($this->feedbackObject());
+
+		$this->assertTrue($result['result']);
+		$this->assertCount($before, glob($pattern) ?: [], 'mail() leaked the temporary screenshot attachment file');
+	}
+
+	/**
 	 * @return array<string, mixed>
 	 */
 	protected function feedbackObject(): array {


### PR DESCRIPTION
`FeedbackstoreTable::mail()` writes the submitted screenshot to a temporary file in `ROOT/tmp` to attach it to the email. On the success path the method `return`s before reaching `unlink($tmpfile)`, so the `unlink()` only ran when sending failed. Every successfully sent feedback mail therefore left a stray `*.png` behind in `tmp/`.

This moves the cleanup into a `finally` block so the temp file is removed on all paths (success, caught exception, or early return). A regression test asserts no `*.png` is left in `ROOT/tmp` after a successful `mail()` — it fails against the previous code (one leaked file) and passes now.
