### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/src/Controller/Admin/FeedbackController.php
+++ b/src/Controller/Admin/FeedbackController.php
@@ -66,10 +66,10 @@ class FeedbackController extends AppController {
 			$feedbackItems = $feedbackItemsTable->find()
 				->select(['id', 'status', 'created', 'name', 'subject', 'priority'])
 				->where(['status' => $entityClass::STATUS_NEW])->all()->toArray();
-			$this->set(['feedbackItems' => $feedbackItems]);
+			$this->set(compact('feedbackItems'));
 		}
 
-		$this->set(['stores' => $stores]);
+		$this->set(compact('stores'));
 	}
 
 	/**

--- a/src/Controller/Admin/FeedbackController.php
+++ b/src/Controller/Admin/FeedbackController.php
@@ -24,7 +24,7 @@ class FeedbackController extends AppController {
 	public function initialize(): void {
 		parent::initialize();
 
-		if (!isset($this->Flash)) {
+		if (!property_exists($this, 'Flash') || $this->Flash === null) {
 			$this->loadComponent('Flash');
 		}
 	}
@@ -55,7 +55,7 @@ class FeedbackController extends AppController {
 				continue;
 			}
 
-			$storeName = substr($store, strrpos($store, '\\') + 1);
+			$storeName = substr((string) $store, strrpos((string) $store, '\\') + 1);
 			$stores[$store] = $storeName;
 		}
 
@@ -66,10 +66,10 @@ class FeedbackController extends AppController {
 			$feedbackItems = $feedbackItemsTable->find()
 				->select(['id', 'status', 'created', 'name', 'subject', 'priority'])
 				->where(['status' => $entityClass::STATUS_NEW])->all()->toArray();
-			$this->set(compact('feedbackItems'));
+			$this->set(['feedbackItems' => $feedbackItems]);
 		}
 
-		$this->set(compact('stores'));
+		$this->set(['stores' => $stores]);
 	}
 
 	/**
@@ -102,7 +102,7 @@ class FeedbackController extends AppController {
 		$basePath = realpath($savepath);
 
 		// Ensure the file is within the allowed directory
-		if (!$realPath || !$basePath || strpos($realPath, $basePath) !== 0) {
+		if (!$realPath || !$basePath || !str_starts_with($realPath, $basePath)) {
 			throw new NotFoundException('Invalid file path');
 		}
 
@@ -134,7 +134,7 @@ class FeedbackController extends AppController {
 		$basePath = realpath($savepath);
 
 		// Ensure the file is within the allowed directory
-		if (!$realPath || !$basePath || strpos($realPath, $basePath) !== 0) {
+		if (!$realPath || !$basePath || !str_starts_with($realPath, $basePath)) {
 			throw new NotFoundException('Invalid file path');
 		}
 

--- a/src/Controller/Admin/FeedbackController.php
+++ b/src/Controller/Admin/FeedbackController.php
@@ -55,7 +55,7 @@ class FeedbackController extends AppController {
 				continue;
 			}
 
-			$storeName = substr((string) $store, strrpos((string) $store, '\\') + 1);
+			$storeName = substr((string)$store, strrpos((string)$store, '\\') + 1);
 			$stores[$store] = $storeName;
 		}
 

--- a/src/Controller/Admin/FeedbackController.php
+++ b/src/Controller/Admin/FeedbackController.php
@@ -24,7 +24,7 @@ class FeedbackController extends AppController {
 	public function initialize(): void {
 		parent::initialize();
 
-		if (!property_exists($this, 'Flash') || $this->Flash === null) {
+		if (!$this->components()->has('Flash')) {
 			$this->loadComponent('Flash');
 		}
 	}
@@ -100,6 +100,9 @@ class FeedbackController extends AppController {
 		$savepath = Configure::read('Feedback.configuration.Filesystem.location');
 		$realPath = realpath($savepath . $file);
 		$basePath = realpath($savepath);
+		if ($basePath) {
+			$basePath = rtrim($basePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+		}
 
 		// Ensure the file is within the allowed directory
 		if (!$realPath || !$basePath || !str_starts_with($realPath, $basePath)) {
@@ -132,6 +135,9 @@ class FeedbackController extends AppController {
 		$savepath = Configure::read('Feedback.configuration.Filesystem.location');
 		$realPath = realpath($savepath . $file);
 		$basePath = realpath($savepath);
+		if ($basePath) {
+			$basePath = rtrim($basePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+		}
 
 		// Ensure the file is within the allowed directory
 		if (!$realPath || !$basePath || !str_starts_with($realPath, $basePath)) {

--- a/src/Controller/Admin/FeedbackItemsController.php
+++ b/src/Controller/Admin/FeedbackItemsController.php
@@ -52,7 +52,7 @@ class FeedbackItemsController extends AppController {
 	public function index() {
 		$feedbackItems = $this->paginate($this->FeedbackItems);
 
-		$this->set(['feedbackItems' => $feedbackItems]);
+		$this->set(compact('feedbackItems'));
 	}
 
 	/**
@@ -64,7 +64,7 @@ class FeedbackItemsController extends AppController {
 	public function view($id = null) {
 		$feedbackItem = $this->FeedbackItems->get($id);
 
-		$this->set(['feedbackItem' => $feedbackItem]);
+		$this->set(compact('feedbackItem'));
 	}
 
 	/**
@@ -101,7 +101,7 @@ class FeedbackItemsController extends AppController {
 			}
 			$this->Flash->error(__d('feedback', 'The feedback item could not be saved. Please, try again.'));
 		}
-		$this->set(['feedbackItem' => $feedbackItem]);
+		$this->set(compact('feedbackItem'));
 	}
 
 	/**

--- a/src/Controller/Admin/FeedbackItemsController.php
+++ b/src/Controller/Admin/FeedbackItemsController.php
@@ -27,7 +27,7 @@ class FeedbackItemsController extends AppController {
 			'created' => 'DESC',
 		];
 
-		if (!property_exists($this, 'Flash') || $this->Flash === null) {
+		if (!$this->components()->has('Flash')) {
 			$this->loadComponent('Flash');
 		}
 	}

--- a/src/Controller/Admin/FeedbackItemsController.php
+++ b/src/Controller/Admin/FeedbackItemsController.php
@@ -27,7 +27,7 @@ class FeedbackItemsController extends AppController {
 			'created' => 'DESC',
 		];
 
-		if (!isset($this->Flash)) {
+		if (!property_exists($this, 'Flash') || $this->Flash === null) {
 			$this->loadComponent('Flash');
 		}
 	}
@@ -52,7 +52,7 @@ class FeedbackItemsController extends AppController {
 	public function index() {
 		$feedbackItems = $this->paginate($this->FeedbackItems);
 
-		$this->set(compact('feedbackItems'));
+		$this->set(['feedbackItems' => $feedbackItems]);
 	}
 
 	/**
@@ -64,7 +64,7 @@ class FeedbackItemsController extends AppController {
 	public function view($id = null) {
 		$feedbackItem = $this->FeedbackItems->get($id);
 
-		$this->set(compact('feedbackItem'));
+		$this->set(['feedbackItem' => $feedbackItem]);
 	}
 
 	/**
@@ -101,7 +101,7 @@ class FeedbackItemsController extends AppController {
 			}
 			$this->Flash->error(__d('feedback', 'The feedback item could not be saved. Please, try again.'));
 		}
-		$this->set(compact('feedbackItem'));
+		$this->set(['feedbackItem' => $feedbackItem]);
 	}
 
 	/**

--- a/src/Controller/FeedbackController.php
+++ b/src/Controller/FeedbackController.php
@@ -26,7 +26,7 @@ class FeedbackController extends AppController {
 	public function initialize(): void {
 		parent::initialize();
 
-		if (!property_exists($this, 'Flash') || $this->Flash === null) {
+		if (!$this->components()->has('Flash')) {
 			$this->loadComponent('Flash');
 		}
 	}
@@ -38,9 +38,11 @@ class FeedbackController extends AppController {
 	 */
 	public function beforeFilter(EventInterface $event): void {
 		// Check FormProtection component loaded and disable it for this plugin:
-		if (property_exists($this, 'FormProtection') && $this->FormProtection !== null) {
-			$this->FormProtection->setConfig('validatePost', false);
-			$this->FormProtection->setConfig('unlockedActions', ['save']);
+		if ($this->components()->has('FormProtection')) {
+			/** @var \Cake\Controller\Component\FormProtectionComponent $formProtection */
+			$formProtection = $this->components()->get('FormProtection');
+			$formProtection->setConfig('validatePost', false);
+			$formProtection->setConfig('unlockedActions', ['save']);
 		}
 
 		if (Configure::read('Feedback')) {
@@ -209,6 +211,9 @@ class FeedbackController extends AppController {
 		$savepath = Configure::read('Feedback.configuration.Filesystem.location');
 		$realPath = realpath($savepath . $file);
 		$basePath = realpath($savepath);
+		if ($basePath) {
+			$basePath = rtrim($basePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+		}
 
 		// Ensure the file is within the allowed directory
 		if (!$realPath || !$basePath || !str_starts_with($realPath, $basePath)) {

--- a/src/Controller/FeedbackController.php
+++ b/src/Controller/FeedbackController.php
@@ -161,13 +161,13 @@ class FeedbackController extends AppController {
 
 		//Prepare result
 		if (!$result['result']) {
-            $this->response = $this->response->withStatus(500);
-            if (empty($result['msg'])) {
+			$this->response = $this->response->withStatus(500);
+			if (empty($result['msg'])) {
 				$result['msg'] = __d('feedback', 'Error saving feedback.');
 			}
-        } elseif (empty($result['msg'])) {
-            $result['msg'] = __d('feedback', 'Your feedback was saved successfully.');
-        }
+		} elseif (empty($result['msg'])) {
+			$result['msg'] = __d('feedback', 'Your feedback was saved successfully.');
+		}
 
 		$this->set('msg', $result['msg']);
 

--- a/src/Controller/FeedbackController.php
+++ b/src/Controller/FeedbackController.php
@@ -26,7 +26,7 @@ class FeedbackController extends AppController {
 	public function initialize(): void {
 		parent::initialize();
 
-		if (!isset($this->Flash)) {
+		if (!property_exists($this, 'Flash') || $this->Flash === null) {
 			$this->loadComponent('Flash');
 		}
 	}
@@ -38,7 +38,7 @@ class FeedbackController extends AppController {
 	 */
 	public function beforeFilter(EventInterface $event): void {
 		// Check FormProtection component loaded and disable it for this plugin:
-		if (isset($this->FormProtection)) {
+		if (property_exists($this, 'FormProtection') && $this->FormProtection !== null) {
 			$this->FormProtection->setConfig('validatePost', false);
 			$this->FormProtection->setConfig('unlockedActions', ['save']);
 		}
@@ -161,16 +161,13 @@ class FeedbackController extends AppController {
 
 		//Prepare result
 		if (!$result['result']) {
-			$this->response = $this->response->withStatus(500);
-
-			if (empty($result['msg'])) {
+            $this->response = $this->response->withStatus(500);
+            if (empty($result['msg'])) {
 				$result['msg'] = __d('feedback', 'Error saving feedback.');
 			}
-		} else {
-			if (empty($result['msg'])) {
-				$result['msg'] = __d('feedback', 'Your feedback was saved successfully.');
-			}
-		}
+        } elseif (empty($result['msg'])) {
+            $result['msg'] = __d('feedback', 'Your feedback was saved successfully.');
+        }
 
 		$this->set('msg', $result['msg']);
 
@@ -214,7 +211,7 @@ class FeedbackController extends AppController {
 		$basePath = realpath($savepath);
 
 		// Ensure the file is within the allowed directory
-		if (!$realPath || !$basePath || strpos($realPath, $basePath) !== 0) {
+		if (!$realPath || !$basePath || !str_starts_with($realPath, $basePath)) {
 			throw new NotFoundException('Invalid file path');
 		}
 

--- a/src/Model/Table/FeedbackstoreTable.php
+++ b/src/Model/Table/FeedbackstoreTable.php
@@ -231,12 +231,12 @@ class FeedbackstoreTable extends Table {
 		$feedbackObject['feedback'] .= sprintf("**By**: %s\n\n", $feedbackObject['name']);
 
 		// WARNING: This may not work for sites with different domains (or dev environments)
-        //          If the given URL is not public, Github won't display the screenshot
-        //Create filename based on timestamp and random number (to prevent collisions)
-        if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
-            $viewimageUrl = Router::url("/img/screenshots/$imagename", true);
-            $feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
-        }
+		//          If the given URL is not public, Github won't display the screenshot
+		//Create filename based on timestamp and random number (to prevent collisions)
+		if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+			$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
+			$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
+		}
 		// Github still doesn't support this kind of image format in Markup Language
 		// $content = '[screenshot]: data:image/png;base64,'. $feedbackObject['screenshot'] . " \n\n";
 
@@ -325,12 +325,12 @@ class FeedbackstoreTable extends Table {
 		$feedbackObject['feedback'] .= sprintf("**Url**: %s\n\n", $feedbackObject['url']);
 
 		// WARNING: This may not work for sites with different domains (or dev environments)
-        //          If the given URL is not public, Bitbucket won't display the screenshot
-        //Create filename based on timestamp and random number (to prevent collisions)
-        if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
-            $viewimageUrl = Router::url("/img/screenshots/$imagename", true);
-            $feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
-        }
+		//          If the given URL is not public, Bitbucket won't display the screenshot
+		//Create filename based on timestamp and random number (to prevent collisions)
+		if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+			$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
+			$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
+		}
 		// Bitbucket still doesn't support this kind of image format in Markup Language
 		// $content = '[screenshot]: data:image/png;base64,'. $feedbackObject['screenshot'] . " \n\n";
 
@@ -347,12 +347,12 @@ class FeedbackstoreTable extends Table {
 			$returnobject['result'] = true;
 			$returnobject['msg'] = __d('feedback', 'Thank you. Your feedback was saved.');
 
-		if (Configure::read('Feedback.returnlink')) {
+			if (Configure::read('Feedback.returnlink')) {
 				$returnobject['msg'] .= '<br/>';
 				$returnobject['msg'] .= __d('feedback', 'View your feedback on:');
 
 				//Get response from github api
-				$answer = json_decode((string) $result->getBody());
+				$answer = json_decode((string)$result->getBody());
 
 				//Create new url:
 				//Replace api prefix with bitbucket public domain:
@@ -403,12 +403,12 @@ class FeedbackstoreTable extends Table {
 		$feedbackObject['feedback'] .= sprintf("**By**: %s\n\n", $feedbackObject['name']);
 
 		// WARNING: This may not work for sites with different domains (or dev environments)
-        //          If the given URL is not public, Jira won't display the screenshot
-        //Create filename based on timestamp and random number (to prevent collisions)
-        if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
-            $viewimageUrl = Router::url("/img/screenshots/$imagename", true);
-            $feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
-        }
+		//          If the given URL is not public, Jira won't display the screenshot
+		//Create filename based on timestamp and random number (to prevent collisions)
+		if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+			$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
+			$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
+		}
 		// Jira still doesn't support this kind of image format in Markup Language
 		// $content = '[screenshot]: data:image/png;base64,'. $feedbackObject['screenshot'] . " \n\n";
 
@@ -575,12 +575,12 @@ class FeedbackstoreTable extends Table {
 		//Serialize and save the object to a store in the Cake's tmp dir.
 		if (!file_exists($savepath) && !mkdir($savepath)) {
 			//Throw error, directory is requird
-            throw new NotFoundException('Could not create directory to save screenshots in. Please provide write rights to webserver user on directory: ' . $savepath);
+			throw new NotFoundException('Could not create directory to save screenshots in. Please provide write rights to webserver user on directory: ' . $savepath);
 		}
 
 		$screenshotname = $this->generateScreenshotName();
 
-		if (file_put_contents($savepath . $screenshotname, base64_decode((string) $feedbackObject['screenshot']))) {
+		if (file_put_contents($savepath . $screenshotname, base64_decode((string)$feedbackObject['screenshot']))) {
 			//Return the screenshotname
 			return $screenshotname;
 		}
@@ -596,7 +596,7 @@ class FeedbackstoreTable extends Table {
 	 * @return string
 	 */
 	private function generateScreenshotName() {
-		return time() . '-' . random_int(1000, 9999) . '.png';
+		return time() . '-' . mt_rand(1000, 9999) . '.png';
 	}
 
 }

--- a/src/Model/Table/FeedbackstoreTable.php
+++ b/src/Model/Table/FeedbackstoreTable.php
@@ -155,7 +155,7 @@ class FeedbackstoreTable extends Table {
 
 		//Tmp store the screenshot:
 		$tmpfile = ROOT . DS . 'tmp' . DS . time() . '_' . mt_rand(1000, 9999) . '.png';
-		if (!file_put_contents($tmpfile, base64_decode($feedbackObject['screenshot']))) {
+		if (!file_put_contents($tmpfile, base64_decode((string) $feedbackObject['screenshot']))) {
 			//Need to save tmp file
 			throw new NotFoundException('Could not save tmp file for attachment in mail');
 		}
@@ -231,15 +231,12 @@ class FeedbackstoreTable extends Table {
 		$feedbackObject['feedback'] .= sprintf("**By**: %s\n\n", $feedbackObject['name']);
 
 		// WARNING: This may not work for sites with different domains (or dev environments)
-		//          If the given URL is not public, Github won't display the screenshot
-		if ($localimagestore) {
-			//Create filename based on timestamp and random number (to prevent collisions)
-		if ($imagename = $this->saveScreenshot($feedbackObject)) {
-				$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
-
-				$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
-			}
-		}
+        //          If the given URL is not public, Github won't display the screenshot
+        //Create filename based on timestamp and random number (to prevent collisions)
+        if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+            $viewimageUrl = Router::url("/img/screenshots/$imagename", true);
+            $feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
+        }
 		// Github still doesn't support this kind of image format in Markup Language
 		// $content = '[screenshot]: data:image/png;base64,'. $feedbackObject['screenshot'] . " \n\n";
 
@@ -268,7 +265,7 @@ class FeedbackstoreTable extends Table {
 		} elseif ($curlstatuscode >= 400) {
 			//Return http error and message
 			$message = json_decode($result);
-			$returnobject['msg'] = trim($message->message); //Can contain linebreaks
+			$returnobject['msg'] = trim((string) $message->message); //Can contain linebreaks
 
 		} else {
 			//Set return value to true and return message
@@ -328,15 +325,12 @@ class FeedbackstoreTable extends Table {
 		$feedbackObject['feedback'] .= sprintf("**Url**: %s\n\n", $feedbackObject['url']);
 
 		// WARNING: This may not work for sites with different domains (or dev environments)
-		//          If the given URL is not public, Bitbucket won't display the screenshot
-		if ($localimagestore) {
-			//Create filename based on timestamp and random number (to prevent collisions)
-		if ($imagename = $this->saveScreenshot($feedbackObject)) {
-				$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
-
-				$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
-			}
-		}
+        //          If the given URL is not public, Bitbucket won't display the screenshot
+        //Create filename based on timestamp and random number (to prevent collisions)
+        if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+            $viewimageUrl = Router::url("/img/screenshots/$imagename", true);
+            $feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
+        }
 		// Bitbucket still doesn't support this kind of image format in Markup Language
 		// $content = '[screenshot]: data:image/png;base64,'. $feedbackObject['screenshot'] . " \n\n";
 
@@ -358,7 +352,7 @@ class FeedbackstoreTable extends Table {
 				$returnobject['msg'] .= __d('feedback', 'View your feedback on:');
 
 				//Get response from github api
-				$answer = json_decode($result->getBody());
+				$answer = json_decode((string) $result->getBody());
 
 				//Create new url:
 				//Replace api prefix with bitbucket public domain:
@@ -409,15 +403,12 @@ class FeedbackstoreTable extends Table {
 		$feedbackObject['feedback'] .= sprintf("**By**: %s\n\n", $feedbackObject['name']);
 
 		// WARNING: This may not work for sites with different domains (or dev environments)
-		//          If the given URL is not public, Jira won't display the screenshot
-		if ($localimagestore) {
-			//Create filename based on timestamp and random number (to prevent collisions)
-		if ($imagename = $this->saveScreenshot($feedbackObject)) {
-				$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
-
-				$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
-			}
-		}
+        //          If the given URL is not public, Jira won't display the screenshot
+        //Create filename based on timestamp and random number (to prevent collisions)
+        if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+            $viewimageUrl = Router::url("/img/screenshots/$imagename", true);
+            $feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
+        }
 		// Jira still doesn't support this kind of image format in Markup Language
 		// $content = '[screenshot]: data:image/png;base64,'. $feedbackObject['screenshot'] . " \n\n";
 
@@ -582,16 +573,14 @@ class FeedbackstoreTable extends Table {
 		$savepath = ROOT . DS . 'files' . DS . 'img' . DS . 'screenshots' . DS;
 
 		//Serialize and save the object to a store in the Cake's tmp dir.
-		if (!file_exists($savepath)) {
-			if (!mkdir($savepath)) {
-				//Throw error, directory is requird
-				throw new NotFoundException('Could not create directory to save screenshots in. Please provide write rights to webserver user on directory: ' . $savepath);
-			}
+		if (!file_exists($savepath) && !mkdir($savepath)) {
+			//Throw error, directory is requird
+            throw new NotFoundException('Could not create directory to save screenshots in. Please provide write rights to webserver user on directory: ' . $savepath);
 		}
 
 		$screenshotname = $this->generateScreenshotName();
 
-		if (file_put_contents($savepath . $screenshotname, base64_decode($feedbackObject['screenshot']))) {
+		if (file_put_contents($savepath . $screenshotname, base64_decode((string) $feedbackObject['screenshot']))) {
 			//Return the screenshotname
 			return $screenshotname;
 		}
@@ -607,7 +596,7 @@ class FeedbackstoreTable extends Table {
 	 * @return string
 	 */
 	private function generateScreenshotName() {
-		return time() . '-' . rand(1000, 9999) . '.png';
+		return time() . '-' . random_int(1000, 9999) . '.png';
 	}
 
 }

--- a/src/Model/Table/FeedbackstoreTable.php
+++ b/src/Model/Table/FeedbackstoreTable.php
@@ -233,7 +233,7 @@ class FeedbackstoreTable extends Table {
 		// WARNING: This may not work for sites with different domains (or dev environments)
 		//          If the given URL is not public, Github won't display the screenshot
 		//Create filename based on timestamp and random number (to prevent collisions)
-		if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+		if ($localimagestore && ($imagename = $this->saveScreenshot($feedbackObject))) {
 			$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
 			$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
 		}
@@ -327,7 +327,7 @@ class FeedbackstoreTable extends Table {
 		// WARNING: This may not work for sites with different domains (or dev environments)
 		//          If the given URL is not public, Bitbucket won't display the screenshot
 		//Create filename based on timestamp and random number (to prevent collisions)
-		if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+		if ($localimagestore && ($imagename = $this->saveScreenshot($feedbackObject))) {
 			$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
 			$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
 		}
@@ -405,7 +405,7 @@ class FeedbackstoreTable extends Table {
 		// WARNING: This may not work for sites with different domains (or dev environments)
 		//          If the given URL is not public, Jira won't display the screenshot
 		//Create filename based on timestamp and random number (to prevent collisions)
-		if ($localimagestore && $imagename = $this->saveScreenshot($feedbackObject)) {
+		if ($localimagestore && ($imagename = $this->saveScreenshot($feedbackObject))) {
 			$viewimageUrl = Router::url("/img/screenshots/$imagename", true);
 			$feedbackObject['feedback'] .= sprintf("**Screenshot**:\n![screenshot](%s)", $viewimageUrl);
 		}

--- a/src/Store/FilesystemStore.php
+++ b/src/Store/FilesystemStore.php
@@ -60,10 +60,11 @@ class FilesystemStore implements StoreInterface {
 		//Serialize and save the object to a store in the Cake's tmp dir.
 		if (!file_exists($location) && !mkdir($location, 0770, true)) {
 			//Throw error, directory is requird
-            throw new NotFoundException('Could not create directory to save feedbacks in. Please provide write rights to webserver user on directory: ' . $location);
+			throw new NotFoundException('Could not create directory to save feedbacks in. Please provide write rights to webserver user on directory: ' . $location);
 		}
-        //Add filename to data
-        return (bool) file_put_contents($location . $object['filename'], serialize($object));
+
+		//Add filename to data
+		return (bool)file_put_contents($location . $object['filename'], serialize($object));
 	}
 
 	/**

--- a/src/Store/FilesystemStore.php
+++ b/src/Store/FilesystemStore.php
@@ -58,19 +58,12 @@ class FilesystemStore implements StoreInterface {
 	 */
 	protected function saveFile(array $object, $location) {
 		//Serialize and save the object to a store in the Cake's tmp dir.
-		if (!file_exists($location)) {
-			if (!mkdir($location, 0770, true)) {
-				//Throw error, directory is requird
-				throw new NotFoundException('Could not create directory to save feedbacks in. Please provide write rights to webserver user on directory: ' . $location);
-			}
+		if (!file_exists($location) && !mkdir($location, 0770, true)) {
+			//Throw error, directory is requird
+            throw new NotFoundException('Could not create directory to save feedbacks in. Please provide write rights to webserver user on directory: ' . $location);
 		}
-
-		if (file_put_contents($location . $object['filename'], serialize($object))) {
-			//Add filename to data
-			return true;
-		}
-
-		return false;
+        //Add filename to data
+        return (bool) file_put_contents($location . $object['filename'], serialize($object));
 	}
 
 	/**

--- a/tests/TestCase/Model/Table/FeedbackstoreTableTest.php
+++ b/tests/TestCase/Model/Table/FeedbackstoreTableTest.php
@@ -82,7 +82,7 @@ class FeedbackstoreTableTest extends TestCase {
 		$threw = false;
 		try {
 			$this->Feedbackstore->mail($feedbackObject);
-		} catch (TypeError $e) {
+		} catch (TypeError) {
 			$threw = true;
 		}
 

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -21,7 +21,7 @@ foreach ($iterator as $file) {
 		$tableObject = (new ReflectionClass($class))->getProperty('table');
 		$tableName = $tableObject->getDefaultValue();
 
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.